### PR TITLE
Update zh_cn for 1.20

### DIFF
--- a/src/main/resources/assets/torchbowmod/lang/en_us.json
+++ b/src/main/resources/assets/torchbowmod/lang/en_us.json
@@ -9,7 +9,7 @@
   "log.sb.error": "Storagebox Load Error.",
   "log.sb.unload": "Storagebox Non-Introduction.",
   "log.sg.check": "Silent's Gems Introduction Status check now.......",
-  "log.sg.load": "Silent's Gemsconfirmed the introduction. Load complete.",
+  "log.sg.load": "Silent's Gems confirmed the introduction. Load complete.",
   "log.sg.error": "Silent's Gems Load Error.",
   "log.sg.unload": "Silent's Gems Non-Introduction."
 }

--- a/src/main/resources/assets/torchbowmod/lang/zh_cn.json
+++ b/src/main/resources/assets/torchbowmod/lang/zh_cn.json
@@ -1,14 +1,15 @@
 {
-  "item.torchbowmod.torchbow": "松明弓",
+  "item.torchbowmod.torchbow": "火把弓",
   "item.torchbowmod.multitorch": "火把组",
-  "itemGroup.torchBowModTab": "松明弓MOD",
-  "death.attack.EntityTorch": "%1$s身上插满了火把！",
+  "item.torchbowmod.torcharrow": "火把箭",
+  "itemGroup.torchBowModTab": "火把弓模组",
+  "death.attack.EntityTorch": "%1$s被%2$s发射的火把刺死了。",
   "log.sb.check": "正在检测StorageBox是否安装……",
-  "log.sb.load": "检测到StorageBox已安装。已读取联动数据",
-  "log.sb.error": "无法读取StorageBox",
+  "log.sb.load": "检测到StorageBox已安装，加载完成。",
+  "log.sb.error": "StorageBox加载错误。",
   "log.sb.unload": "StorageBox没有安装。",
   "log.sg.check": "正在检测Silent's Gems是否安装……",
-  "log.sg.load": "检测到Silent's Gems已安装。已读取联动数据",
-  "log.sg.error": "无法读取Silent's Gems",
+  "log.sg.load": "检测到Silent's Gems已安装，加载完成。",
+  "log.sg.error": "Silent's Gems加载错误。",
   "log.sg.unload": "Silent's Gems没有安装。"
 }


### PR DESCRIPTION
Torch's official translation is `火把` instead of `松明`. `松明` is Japanese name.
![image](https://github.com/noriokun4649/TorchBowMod/assets/37864486/1de6655e-2d2b-4d1a-a50e-974ea028c574)
https://minecraft.fandom.com/zh/wiki/Minecraft_Wiki:%E8%AF%91%E5%90%8D%E6%A0%87%E5%87%86%E5%8C%96